### PR TITLE
link fixes

### DIFF
--- a/docs/blacksky-info/blacksky-feeds-hashtags.md
+++ b/docs/blacksky-info/blacksky-feeds-hashtags.md
@@ -6,7 +6,7 @@ They are not. Custom feeds in Bluesky are aggregators of content, not forums. Yo
 
 So, clicking the #Blacksky hashtag is not the same as using the official Blacksky Feed. The feed is chronologically ordered and the content is curated through human moderation, automation, and some pre-filtering logic.
 
-The community also proactively reports content to our Blacksky Moderation Service [@blacksky.app](https://bsky.app/profile/blacksky.app). Also, see [How Do I Add Myself to the Blacksky Feed](docs/blacksky-info/how-to-add.md).
+The community also proactively reports content to our Blacksky Moderation Service [@blacksky.app](https://bsky.app/profile/blacksky.app). Also, see [How Do I Add Myself to the Blacksky Feed](/docs/blacksky-info/how-to-add).
 
 A starter pack is a list of users and feeds that help new users find community quicker. The Blacksky Starter Pack is a curated list of the 50 most popular and active accounts from the Blacksky feeds.
 

--- a/docs/blacksky-info/blacksky-moderation.md
+++ b/docs/blacksky-info/blacksky-moderation.md
@@ -3,7 +3,7 @@
 Any content labeled by Bluesky's AI-based labeler is automatically filtered out of the feed as soon as it is labeled. This usually occurs at the time of posting, but can happen later.
 [Defined by Bluesky](https://bsky.social/about/blog/03-12-2024-stackable-moderation), labels are annotations on users and content. They can be used to hide, warn, and categorize [posts, and users on] the network
 
-The Blacksky Moderation Service, @blacksky.app, is where you can report posts for antiblackness and misogynoir. The service is also a labeler that you can subscribe to in order to be warned about harmful or insensitive content. Also see, [How Do I Subscribe to the Blacksky Moderation Service Labeler](/docs/blacksky-info/how-to-add.md#labeler)
+The Blacksky Moderation Service, @blacksky.app, is where you can report posts for antiblackness and misogynoir. The service is also a labeler that you can subscribe to in order to be warned about harmful or insensitive content. Also see, [How Do I Subscribe to the Blacksky Moderation Service Labeler](/docs/blacksky-info/how-to-add#labeler)
 
 Other content that doesn't belong in the feed can be reported to [@blacksky.app](https://bsky.app/profile/blacksky.app), where a team of moderators will review the content for removal from the feed.
 
@@ -27,7 +27,7 @@ Report that to @blacksky.app.\
 \
 See something that could otherwise harm Black folks (e.g. screenshots of racist posts on X)? Report to @blacksky.app
 
-Also, see [How to Do I Report a Post to the Blacksky Moderation Service](/docs/blacksky-intro.md#How-do-I-Report-a-Post-to-the-Blacksky-Moderation-Service?) (blacksky.app)? and XXX.
+Also, see [How to Do I Report a Post to the Blacksky Moderation Service](/docs#how-do-i-report-a-post-to-the-blacksky-moderation-service) (blacksky.app)?
 
 The moderation service gives you a discrete way to report harmful content but it also allows Blacksky to enable features that protect the community. For example, the Blacksky “Banned from TV” feature allows for certain accounts that are reported to be blocked from even seeing the feed.
 

--- a/docs/blacksky-info/how-to-add.md
+++ b/docs/blacksky-info/how-to-add.md
@@ -8,12 +8,12 @@ There are several feeds created by Blacksky Algorithms:
 
 > Note: You may see that the feeds are authored by "@rudyfraser.com". Those are the right feeds.
 
-### joining-a-blacksky-feed
+### Joining a Blacksky Feed
 Create a post and include the #AddToBlacksky hashtag (This only needs to be done once). All posts after will be included in the Blacksky feed.
 
 ![A screenshot of post on Bluesky including text that states "This is an example of a post", and "#AddToBlacksky". This is to showcase how a user can get their posts included in the Blacksky feed.](../../static/img/exampleBskyPost.png)
 
-### leaving-a-blacksky-feed
+### Leaving a Blacksky Feed
 Create a post and include the #RemoveFromBlacksky hashtag. All posts after will NOT be included in any of the Blacksky feeds.
 
 ![A screenshot of post on Bluesky including text that states "This is another example post", and "#RemoveFromBlacksky". This is to showcase how a user can get their posts included in the Blacksky feed](../../static/img/exampleBskyPostTwo.png)

--- a/docs/blacksky-info/how-to-add.md
+++ b/docs/blacksky-info/how-to-add.md
@@ -8,18 +8,18 @@ There are several feeds created by Blacksky Algorithms:
 
 > Note: You may see that the feeds are authored by "@rudyfraser.com". Those are the right feeds.
 
-### Joining a Blacksky Feed
+### joining-a-blacksky-feed
 Create a post and include the #AddToBlacksky hashtag (This only needs to be done once). All posts after will be included in the Blacksky feed.
 
 ![A screenshot of post on Bluesky including text that states "This is an example of a post", and "#AddToBlacksky". This is to showcase how a user can get their posts included in the Blacksky feed.](../../static/img/exampleBskyPost.png)
 
-### Leaving a Blacksky Feed
+### leaving-a-blacksky-feed
 Create a post and include the #RemoveFromBlacksky hashtag. All posts after will NOT be included in any of the Blacksky feeds.
 
 ![A screenshot of post on Bluesky including text that states "This is another example post", and "#RemoveFromBlacksky". This is to showcase how a user can get their posts included in the Blacksky feed](../../static/img/exampleBskyPostTwo.png)
 
 ### Pinning a Feed
-1. Open the [Bluesky](www.bsky.app) app.
+1. Open the [Bluesky](https://bsky.app) app.
 2. Navigate to the search page.
 3. Type in the title of any of the feeds previously mentioned.
 4. Click on the "+" to join this feed.

--- a/docs/blacksky-intro.md
+++ b/docs/blacksky-intro.md
@@ -14,10 +14,10 @@ The Authenticated Transfer Protocol (aka atproto) is the decentralized social ne
 Here's a [link to a Bluesky blog](https://bsky.social/about/blog/02-22-2024-open-social-web) post that explains what it is, and why it differs from other social apps you may be used to.
 
 ### How do I Add Myself to the Blacksky Feed?
-See [Joining a Blacksky Feed](/docs/blacksky-info/how-to-add.md#Joining-a-Blacksky-Feed).
+See [Joining a Blacksky Feed](/docs/blacksky-info/how-to-add#joining-a-blacksky-feed).
 
 ### How do I Remove Myself from the Blacksky Feed or Starter Pack?
-See [Leaving a Blacksky Feed](/docs/blacksky-info/how-to-add.md#Leaving-a-Blacksky-Feed).
+See [Leaving a Blacksky Feed](/docs/blacksky-info/how-to-add#leaving-a-blacksky-feed).
 
 ### How do I Report a Post to the Blacksky Moderation Service?
 To report a post:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -85,7 +85,7 @@ const config: Config = {
           items: [
             {
               label: "Blacksky Introduction",
-              to: "/docs/blacksky-intro",
+              to: "/docs",
             },
           ],
         },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro"
+            to="/docs"
           >
             Intro to Blacksky - 5 min
           </Link>


### PR DESCRIPTION
  1. Fixed the broken links to /docs/blacksky-intro by changing the configuration to work with the slug setting in the frontmatter.
  2. Fixed the broken link to http://www.bsky.app in how-to-add.md by changing the URL from https://www.bsky.app to https://bsky.app.
  3. Fixed the anchor links by:
    - Changing heading format in how-to-add.md to use lowercase and hyphens
    - Updating references in blacksky-intro.md and blacksky-moderation.md to use the correct anchor format
    - Fixing the reference to the labeler section